### PR TITLE
(feature) Parallelising various GATK processes for speed-up

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -38,7 +38,7 @@ workflow {
     //       OR let each process accept a val(x) and then on each process determine whether its a tuple
     if (params.paired) {
         // TODO: placing the "." inside i.e  [.gz|.bz2] causes it to not function?
-        INPUT_READS = Channel.fromFilePairs("${params.input_dir}/*{${params.r1_pattern},${params.r2_pattern}}*.f*q.[gz|bz2]?",
+        INPUT_READS = Channel.fromFilePairs("${params.input_dir}/**/*{${params.r1_pattern},${params.r2_pattern}}*.f*q.[gz|bz2]?",
                                             type: 'file',
                                             maxDepth: 5)
     } else {

--- a/main.nf
+++ b/main.nf
@@ -47,7 +47,11 @@ workflow {
                     .map(read -> tuple(read.simpleName, read))
     }
 
-    INPUT_READS.view()
+    // Temporary filter, move them out of dir when permissions allow, it removes all DNA-fastq's
+    // INPUT_READS.filter { !it[0].startsWith("FO")  }
+    // INPUT_READS.view()
+
+
     QC_READS = QUALITYCONTROL(INPUT_READS)
     MAPPING(QC_READS, REFERENCE)
     VARIANT_CALLING(MAPPING.out, REFERENCE) // Places files in output folder

--- a/mapping.nf
+++ b/mapping.nf
@@ -1,21 +1,23 @@
 process SAMTOOLS_SORT {
     label 'mapping'
     input:
-        tuple val(sample_id), path(sam_file)
+        tuple val(sample_id), path(xam_file) //bam or sam
 
     output:
-        tuple val(sample_id), path("*.bam")
+        tuple val(sample_id), path("${xam_file.simpleName}.bam")
 
     script:
 
     """
-    echo "Sorting ${sam_file}"
-    samtools sort -@ ${task.cpus} -o ${sam_file.simpleName}.bam ${sam_file}
+    echo "Sorting ${xam_file}"
+    mv ${xam_file} temp.ext # Avoid bam->bam name collision
+    samtools sort -@ ${task.cpus} -o ${xam_file.simpleName}.bam temp.ext
+    #samtools sort -@ ${task.cpus} -o ${xam_file.simpleName}.bam ${xam_file}
     """
 
     stub:
     """
-    touch ${sam_file.simpleName}.bam
+    touch ${xam_file.simpleName}.bam
     """
 }
 

--- a/mapping.nf
+++ b/mapping.nf
@@ -198,7 +198,10 @@ workflow MAPPING {
             ref_idx = HISAT_BUILD(ref_file).collect() 
             sorted_index_bams = HISAT2(reads, ref_idx) | SAMTOOLS_SORT | SAMTOOLS_INDEX
         } else if (mapping_method == "star") {
-            ref_idx = STAR_BUILD(ref_file, ANNOTATION).collect()
+        ref_idx = params.genome_index != '' ?
+            Channel.fromPath("${params.genome_index}/*").collect() :
+            STAR_BUILD(ref_file, ANNOTATION).collect()
+
             sorted_index_bams = STAR(reads,ref_idx) | SAMTOOLS_INDEX
         } else {
             println "ERROR: Mapping method not recognised"

--- a/mapping.nf
+++ b/mapping.nf
@@ -1,10 +1,10 @@
 process SAMTOOLS_SORT {
     label 'mapping'
     input:
-        path sam_file
+        tuple val(sample_id), path(sam_file)
 
     output:
-        path "*.bam"
+        tuple val(sample_id), path("*.bam")
 
     script:
 
@@ -16,6 +16,30 @@ process SAMTOOLS_SORT {
     stub:
     """
     touch ${sam_file.simpleName}.bam
+    """
+}
+
+
+process SAMTOOLS_INDEX {
+    label 'mapping'
+    input:
+        tuple val(sample_id), path(bam_file)
+
+    // TODO: Do we have *.bai and bam separate or as one?
+    // As one would make more sense?
+    output:
+        tuple val(sample_id), path(bam_file), path("*.bai")
+
+    script:
+
+    """
+    echo "Sorting ${bam_file}"
+    samtools index -@ ${task.cpus} -o ${bam_file.simpleName}.bai ${bam_file}
+    """
+
+    stub:
+    """
+    touch ${bam_file.simpleName}.bai
     """
 }
 
@@ -49,7 +73,7 @@ process HISAT2 {
         tuple val(sample_id), path(reads)
         path ref_idx
     output:
-        path "*.sam"
+        tuple val(sample_id), path("*.sam")
 
     script:
     def (read1,read2) = [reads[0], reads[1]]
@@ -74,6 +98,7 @@ process HISAT2 {
 }
 
 process STAR_BUILD {
+    publishDir "${params.output_dir}/star_index", mode: 'copy', pattern: '*'
     label 'mapping'
     input:
         path ref_file
@@ -83,7 +108,7 @@ process STAR_BUILD {
 
     script:
     def READ_LENGTH = 100
-    def feature = "gene"
+    def feature = "exon"
     def extension = annotation.extension // Remove this when changing to *_args
     def extension_args = annotation.extension == "gtf" ? "" :
         "--sjdbGTFtagExonParentTranscript Parent --sjdbGTFfeatureExon $feature"
@@ -122,14 +147,14 @@ process STAR_BUILD {
 process STAR {
     label 'mapping'
     publishDir "${params.output_dir}/star_summaries", mode: 'copy', pattern: '*.final.out'
-    publishDir "${params.output_dir}/bams", mode: 'copy', pattern: '*.bam'
+    publishDir "${params.output_dir}/aligned_bams", mode: 'copy', pattern: '*.bam'
 
     input:
         tuple val(sample_id), path(reads)
         path ref_idx
 
     output:
-        path "*.bam"
+        tuple val(sample_id),  path("*.bam")
 
     script:
     // No strand-specific options needed here
@@ -165,16 +190,17 @@ workflow MAPPING {
         reads
         ref_file
     main:
+        ANNOTATION = Channel.fromPath(params.gff_file)
         mapping_method = params.mapping.toLowerCase()
         if (mapping_method == "hisat2") {
             ref_idx = HISAT_BUILD(ref_file).collect() 
-            sorted_bams = HISAT2(reads, ref_idx) | SAMTOOLS_SORT
+            sorted_index_bams = HISAT2(reads, ref_idx) | SAMTOOLS_SORT | SAMTOOLS_INDEX
         } else if (mapping_method == "star") {
-            ref_idx = STAR_BUILD(ref_file, Channel.fromPath(params.gff_file)).collect()
-            sorted_bams = STAR(reads,ref_idx) // The command itself aligns the bams
+            ref_idx = STAR_BUILD(ref_file, ANNOTATION).collect()
+            sorted_index_bams = STAR(reads,ref_idx) | SAMTOOLS_INDEX
         } else {
             println "ERROR: Mapping method not recognised"
         }
     emit:
-        sorted_bams // output STAR/Hisat2 bam files (sorted)
+        sorted_index_bams // tuple sample_id, bam and bai
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,10 +35,12 @@ profiles {
     singularity {
         singularity.enabled = true
         singularity.autoMounts = true
-        singularity.runOptions = '-B $SINGULARITY_TMPDIR:/tmp' // -B $SINGULARITYENV_TMPDIR:/tmp
+        singularity.runOptions = '-B $SINGULARITY_TMPDIR:/tmp --no-mount /nfs/wsi/it/posth' // -B $SINGULARITYENV_TMPDIR:/tmp
         singularity.envWhitelist = ['SINGULARITY_TMPDIR', 'APPTAINERENV_TMPDIR', 'SINGULARITYENV_TMPDIR']
         executor {
             name = 'slurm'
+            // queueSize = 200
+            pollInterval = '30 sec'
         }
 
         process {

--- a/nextflow.config
+++ b/nextflow.config
@@ -73,7 +73,6 @@ profiles {
                 // maxForks = 8 // If not SLURM executor
                 errorStrategy = 'retry' // For gatk-related processes
                 maxRetries = 3          // For gatk-related processes
-
                 queue = 'long'
                 memory = 20.GB
                 cpus = 4

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,11 +69,13 @@ profiles {
             }
             withLabel: variant_calling {
                 // maxForks = 8 // If not SLURM executor
-                queue = 'short'
-                memory = 20.GB
-                cpus = 6
-            }
+                errorStrategy = 'retry' // For gatk-related processes
+                maxRetries = 3          // For gatk-related processes
 
+                queue = 'long'
+                memory = 20.GB
+                cpus = 4
+            }
             withName: STAR_BUILD {
                 cpus = 20
                 memory = 50.GB

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,7 +59,7 @@ profiles {
                 // maxForks = 8 // If not SLURM executor
                 queue = 'short'
                 memory = 20.GB
-                cpus = 6
+                cpus = 10
             }
             withLabel: assembly {
                 // maxForks = 6 // If not SLURM executor

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ params {
     num_threads     = 4; 
     max_memory      = '50.GB';
 
+    genome_index    = '';
 
     paired          = false;                 // Whether paired data is given
     strandedness    = "forward"

--- a/nextflow.config
+++ b/nextflow.config
@@ -35,8 +35,12 @@ profiles {
     singularity {
         singularity.enabled = true
         singularity.autoMounts = true
-        singularity.runOptions = '-B $SINGULARITY_TMPDIR:/tmp'
-        singularity.envWhitelist = ['SINGULARITY_TMPDIR']
+        singularity.runOptions = '-B $SINGULARITY_TMPDIR:/tmp' // -B $SINGULARITYENV_TMPDIR:/tmp
+        singularity.envWhitelist = ['SINGULARITY_TMPDIR', 'APPTAINERENV_TMPDIR', 'SINGULARITYENV_TMPDIR']
+        executor {
+            name = 'slurm'
+        }
+
         process {
             // Labels to take into consideration:
             // storeDir, queue ...
@@ -44,7 +48,7 @@ profiles {
             // TODO: Does SLURM do per process or per process instance
             container = 'file://clint.sif'
             cpus = 4
-            executor = 'slurm'
+            // executor = 'slurm'
             withLabel: preprocess {
                 // maxForks = 7 // If not SLURM executor
                 queue = 'short'

--- a/variant_calling.nf
+++ b/variant_calling.nf
@@ -1,16 +1,45 @@
+process REFERENCE_HELP_FILES {
+    // This process mainly relates to the necessary side-files
+    // such as the .fai and .dict files for the reference genome
+    // as these are required in some of the processes
+
+    input:
+        path ref_file
+
+    output:
+        path "${ref_file}.fai" emit: fai
+        path "${ref_file.baseName}.dict" emit: dict
+        // stdout emit: verbo
+
+
+    script:
+    """
+    echo "Running samtools faidx and docker"
+    samtools faidx ${ref_file}
+    gatk CreateSequenceDictionary -R \$PWD/${ref_file} -O \$PWD/${ref_file.baseName}.dict
+    ls -lah
+    """
+
+    stub:
+    """
+    touch ${ref_file}.fai
+    touch ${ref_file.baseName}.dict
+    """
+}
+
 process MarkDuplicates {
     // NOTE: We an add --REMOVE_DUPLICATES=true to remove duplicates from the final BAM file
     //       intead of just switching the flag for that read
     label 'variant_calling'
     publishDir "${params.output_dir}/deduped_bam/", mode: 'copy', overwrite: true
     input:
-        path aligned_bam
+        tuple val(sample_id), path(aligned_bam), path(bai)
 
     output:
-        path "dedup_${aligned_bam}"
-
+        tuple val(sample_id), path("dedup_*"), path(bai)
 
     script:
+    // TODO: Add "--remove-duplicates" options maybe? To actually remove the duplicates
     """
     echo "Working on ${aligned_bam}"
     gatk MarkDuplicates -I \$PWD/${aligned_bam} -O \$PWD/dedup_${aligned_bam} -M \$PWD/dedup_${aligned_bam}.metrics
@@ -25,25 +54,82 @@ process MarkDuplicates {
 process SplitNCigarReads {
     label 'variant_calling'
     input:
-        path aligned_bam
+        tuple val(sample_id), path(bam), path(bai)
         path ref_fai
         path ref_dict
         path ref
 
     output:
-        path "snc_${aligned_bam}"
+        tuple val(sample_id), path("snc_*"), path(bai)
         // stdout emit: temp
     
 
+    // TODO: Parallelise using interval list, in pairs of 2
+    // TODO :This is currently done as a single process/job submission, maybe split it into multiple jobs? Then collect and converge
+    // FIXME: This might just be overwriting at each interval, so do the looping somewhere else
     script:
+    def chromosomes = (1..22) + ['X', 'Y']
+
     """
-    echo "Working on ${aligned_bam}"
-    gatk SplitNCigarReads -R \$PWD/${ref} -I \$PWD/${aligned_bam} -O \$PWD/snc_${aligned_bam}
+    chromosomes=({1..22} X Y)
+    for i in "\${chromosomes[@]}"; do
+        echo "Working on ${bam}"
+        gatk SplitNCigarReads -R \$PWD/${ref} -I \$PWD/${bam} -O \$PWD/snc_${bam} -L \${i}
+    #done
+    #echo "Working on ${bam}"
+    #gatk SplitNCigarReads -R \$PWD/${ref} -I \$PWD/${bam} -O \$PWD/snc_${bam}
     """
 
     stub:
     """
-    touch snc_${aligned_bam}
+    touch snc_${bam_bai}
+    """
+}
+
+process HaplotypeCaller {
+    label 'variant_calling'
+    publishDir "${params.output_dir}/haplotype_vcf/rna_spades", mode: 'copy', overwrite: true, pattern: "*spades_*.vcf"
+    publishDir "${params.output_dir}/haplotype_vcf/Trinity-GG", mode: 'copy', overwrite: true, pattern: "*Trinity-GG_*.vcf"
+    // FIXME: Maybe fix this so that non-assembled ones have their own name? But currently based upon that
+    //        only the non-assembled ones don't have a method between "snc" and "trimmed"
+    publishDir "${params.output_dir}/haplotype_vcf/normal", mode: 'copy', overwrite: true, pattern: "*snc_trimmed*.vcf"
+    input:
+        tuple val(sample_id), path("snc_*"), path(bai)
+        path ref_fai
+        path ref_dict
+        path ref
+
+    output:
+        path "haplotype_*.vcf"
+
+
+    // TODO: Change to Mutec2 since HaplotypeCaller is Germline, and we are doing somatic
+    // TODO: Split by chromosome. Either have a for loop in the command block (each of them uses chromosome interval)
+    // or then do it on the process-level
+    // TODO: Implement bcftools concat to merge them back together
+    // TODO: Remove samtools index from here, and instead propogate the ".bai" file throughout the proceeses
+    //      This would require modifying input for the previous steps
+    script:
+    """
+    echo "Working on ${split_bam}"
+    samtools index ${split_bam}
+
+    chromosomes=({1..22} X Y)
+    for i in "\${chromosomes[@]}"; do
+        echo "Working on ${split_bam}"
+        gatk --java-options '-Xmx4G -XX:+UseParallelGC -XX:ParallelGCThreads=4' HaplotypeCaller \
+            --pair-hmm-implementation FASTEST_AVAILABLE \
+            --native-pair-hmm-threads ${task.cpus} \
+            --smith-waterman FASTEST_AVAILABLE \
+            -R \$PWD/${ref} -I \$PWD/${split_bam} -O \$PWD/haplotype_${split_bam}.vcf
+    done
+    #touch haplotype_${split_bam.simpleName}.vcf
+    ls -lah
+    """
+
+    stub:
+    """
+    touch haplotype_${split_bam.simpleName}.vcf
     """
 }
 
@@ -83,88 +169,24 @@ process VariantFiltering {
     """
 }
 
-process HaplotypeCaller {
-    label 'variant_calling'
-    publishDir "${params.output_dir}/haplotype_vcf/rna_spades", mode: 'copy', overwrite: true, pattern: "*spades_*.vcf"
-    publishDir "${params.output_dir}/haplotype_vcf/Trinity-GG", mode: 'copy', overwrite: true, pattern: "*Trinity-GG_*.vcf"
-    // FIXME: Maybe fix this so that non-assembled ones have their own name? But currently based upon that
-    //        only the non-assembled ones don't have a method between "snc" and "trimmed"
-    publishDir "${params.output_dir}/haplotype_vcf/normal", mode: 'copy', overwrite: true, pattern: "*snc_trimmed*.vcf"
-    input:
-        path split_bam
-        path ref_fai
-        path ref_dict
-        path ref
-
-    output:
-        path "haplotype_*.vcf"
-
-
-    // TODO: Split by chromosome. Either have a for loop in the command block (each of them uses chromosome interval)
-    // or then do it on the process-level
-    script:
-    """
-    echo "Working on ${split_bam}"
-    samtools index ${split_bam}
-    gatk --java-options '-Xmx4G -XX:+UseParallelGC -XX:ParallelGCThreads=4' HaplotypeCaller \
-    --pair-hmm-implementation FASTEST_AVAILABLE \
-    --smith-waterman FASTEST_AVAILABLE \
-    -R \$PWD/${ref} -I \$PWD/${split_bam} -O \$PWD/haplotype_${split_bam}.vcf
-    #touch haplotype_${split_bam.simpleName}.vcf
-    ls -lah
-    """
-
-    stub:
-    """
-    touch haplotype_${split_bam.simpleName}.vcf
-    """
-}
-
-
-process REFERENCE_HELP_FILES {
-    // This process mainly relates to the necessary side-files
-    // such as the .fai and .dict files for the reference genome
-    // as these are required in some of the processes
-
-    input: 
-        path ref_file
-
-    output:
-        path "${ref_file}.fai" 
-        path "${ref_file.baseName}.dict" 
-        // stdout emit: verbo
-
-
-    script:
-    """
-    echo "Running samtools faidx and docker"
-    samtools faidx ${ref_file}
-    gatk CreateSequenceDictionary -R \$PWD/${ref_file} -O \$PWD/${ref_file.baseName}.dict
-    ls -lah
-    """
-
-    stub:
-    """
-    touch ${ref_file}.fai
-    touch ${ref_file.baseName}.dict
-    """
-}
 
 workflow VARIANT_CALLING {
-    // Run SplitNCigarReads and HaplotypeCaller
-
     take:
-        bam
+        sorted_index_bam // Sample ID + BAM/BAI
         ref
     main:
         // TODO: Combine ref_fai, ref_dict and ref into one thing
         REFERENCE_HELP_FILES(ref)
         (ref_fai, ref_dict) = REFERENCE_HELP_FILES.out
-        split_bam = SplitNCigarReads(bam, ref_fai, ref_dict, ref) | MarkDuplicates
-        // SplitNCigarReads.out.view()
-        haplotype_vcf = HaplotypeCaller(split_bam, ref_fai, ref_dict, ref)
+
+        // TODO: For each sample id, split bam up to process, and then merge them back together
+        bam_split_n = SplitNCigarReads(sorted_index_bam, ref_fai, ref_dict, ref)
+        // | MarkDuplicates
+        // haplotype_vcf = HaplotypeCaller(bam_split_n, ref_fai, ref_dict, ref)
     emit:
         // split_bam
         haplotype_vcf
 }
 
+// TODO: Avoid sending tuple from sorted_index_bam to all the others (since some of them require )
+// use named outputs?

--- a/variant_calling.nf
+++ b/variant_calling.nf
@@ -77,11 +77,11 @@ process SplitNCigarReads {
         interval_args += " -L ${chr}"
         name += "${chr}_"
     }
-    println "Processing SplitNCigarReads for ${interval_args}"
+    println "Processing SplitNCigarReads for ${interval_args} for ${sample_id}"
 
     """
     echo "Working on ${bam}"
-    gatk SplitNCigarReads -R \$PWD/${ref} -I \$PWD/${bam} -O \$PWD/${name}.bam ${interval_args}
+    gatk SplitNCigarReads -R ${ref} -I ${bam} -O ${name}.bam ${interval_args}
     """
 
     stub:
@@ -121,15 +121,20 @@ process Mutect2 {
         interval_args += " -L ${chr}"
         name += "${chr}_"
     }
+
     println "Processing mutect2 in interval ${interval_args}"
+
     """
     echo "Working on ${split_bam}"
     gatk --java-options '-Xmx4G -XX:+UseParallelGC -XX:ParallelGCThreads=${task.cpus}' Mutect2 \
         --pair-hmm-implementation FASTEST_AVAILABLE \
         --native-pair-hmm-threads ${task.cpus} \
         --smith-waterman FASTEST_AVAILABLE \
-        -R \$PWD/${ref} -I \$PWD/${split_bam} -O \$PWD/${name}.vcf \
-        ${interval_args}
+        -R ${ref} \
+        -I ${split_bam} \
+        --f1r2-tar-gz f1r2.tar.gz \
+        ${interval_args} \
+        -O ${name}.vcf \
     # touch haplotype_${name}.vcf
     # ls -lah
     """
@@ -139,6 +144,7 @@ process Mutect2 {
     touch haplotype_${split_bam.simpleName}.vcf
     """
 }
+
 
 
 process MergeBams {

--- a/variant_calling.nf
+++ b/variant_calling.nf
@@ -90,21 +90,22 @@ process SplitNCigarReads {
     """
 }
 
-process HaplotypeCaller {
+process Mutect2 {
     label 'variant_calling'
-    publishDir "${params.output_dir}/haplotype_vcf/rna_spades", mode: 'copy', overwrite: true, pattern: "*spades_*.vcf"
-    publishDir "${params.output_dir}/haplotype_vcf/Trinity-GG", mode: 'copy', overwrite: true, pattern: "*Trinity-GG_*.vcf"
+    publishDir "${params.output_dir}/vcf/intermediate/rna_spades", mode: 'copy', overwrite: true, pattern: "*spades_*.vcf"
+    publishDir "${params.output_dir}/vcf/intermediate/Trinity-GG", mode: 'copy', overwrite: true, pattern: "*Trinity-GG_*.vcf"
     // FIXME: Maybe fix this so that non-assembled ones have their own name? But currently based upon that
     //        only the non-assembled ones don't have a method between "snc" and "trimmed"
-    publishDir "${params.output_dir}/haplotype_vcf/normal", mode: 'copy', overwrite: true, pattern: "*snc_trimmed*.vcf"
+    publishDir "${params.output_dir}/vcf/intermediate/normal", mode: 'copy', overwrite: true, pattern: "*snc*.vcf"
     input:
-        tuple val(sample_id), path("snc_*"), path(bai)
+        tuple val(sample_id), path(split_bam), path(bai)
         path ref_fai
         path ref_dict
         path ref
+        each chr_interval
 
     output:
-        path "haplotype_*.vcf"
+        tuple val(sample_id), path("*.vcf")
 
 
     // TODO: Change to Mutec2 since HaplotypeCaller is Germline, and we are doing somatic

--- a/variant_calling.nf
+++ b/variant_calling.nf
@@ -105,15 +105,10 @@ process Mutect2 {
         each chr_interval
 
     output:
-        tuple val(sample_id), path("*.vcf")
+        tuple val(sample_id), path("*.vcf"), emit: vcfs
+        tuple val(sample_id), path("*.tar.gz"), emit: f1r2
+        tuple val(sample_id), path("*.stats"), emit: stats
 
-
-    // TODO: Change to Mutec2 since HaplotypeCaller is Germline, and we are doing somatic
-    // TODO: Split by chromosome. Either have a for loop in the command block (each of them uses chromosome interval)
-    // or then do it on the process-level
-    // TODO: Implement bcftools concat to merge them back together
-    // TODO: Remove samtools index from here, and instead propogate the ".bai" file throughout the proceeses
-    //      This would require modifying input for the previous steps
     script:
     def name = "haplotype_${split_bam.simpleName}."
     def interval_args = ""

--- a/variant_calling.nf
+++ b/variant_calling.nf
@@ -211,17 +211,25 @@ workflow VARIANT_CALLING {
                                        REF_AUXILLARY.out.fai,
                                        REF_AUXILLARY.out.dict,
                                        REF_AUXILLARY.out.ref,
-                                       groupedPairs) // or [chromosomes]
+                                       groups) // or [chromosomes]
             .groupTuple() | MergeBams | SAMTOOLS_SORT | MarkDuplicates | SAMTOOLS_INDEX
 
-        haplotype_vcf = Mutect2(bam_split_n,
-                                REF_AUXILLARY.out.fai,
-                                REF_AUXILLARY.out.dict,
-                                REF_AUXILLARY.out.ref,
-                                groupedPairs) .groupTuple() | MergeVcfs
-        // haplotype_vcf
-    emit:
-        haplotype_vcf
+
+        Mutect2(bam_split_n,
+                REF_AUXILLARY.out.fai,
+                REF_AUXILLARY.out.dict,
+                REF_AUXILLARY.out.ref,
+                groups)
+
+    // Collect for each sample ID (i.e paired end read set) the (per-chromosome) scattered
+    // vcfs & f1r2, to be merged
+        vcfs = Mutect2.out.vcfs.groupTuple()
+        f1r2 = Mutect2.out.f1r2.groupTuple()
+
+
+    // haplotype_vcf
+    // emit:
+    //     Mutect2.out
 }
 
 // TODO: Avoid sending tuple from sorted_index_bam to all the others (since some of them require )

--- a/variant_processing.nf
+++ b/variant_processing.nf
@@ -1,0 +1,48 @@
+process VariantFiltering {
+    label 'variant_calling'
+    publishDir "${params.output_dir}/vcf/filtered/rna_spades", mode: 'copy', overwrite: true, pattern: "*spades_*.vcf"
+    publishDir "${params.output_dir}/vcf/filtered/Trinity-GG", mode: 'copy', overwrite: true, pattern: "*Trinity-GG_*.vcf"
+    publishDir "${params.output_dir}/vcf/filtered/normal", mode: 'copy', overwrite: true, pattern: "*snc*.vcf"
+
+    input:
+        tuple val(sample_id), path(vcf)
+        path ref
+        path ref_fai
+        path ref_dict
+
+    output:
+        path "*.vcf"
+
+    script:
+    // Layout: [Filter Expression, Filtername]
+    def filter_options = [
+        ["FS > 20", "FS20"]
+        ["QUAL > 20", "FS20"]
+        ]
+    def filtering_args = ""
+    filter_options.each { expr, name ->
+        filtering_args += "--genotype-filter-expression \"${expr}\" --genotype-filter-name \"${name}\" "
+    }
+    println ${filtering_args}
+    // TODO: Integrate the filtering args into the command block
+    """
+    gatk --java-options '-Xmx4G -XX:+UseParallelGC -XX:ParallelGCThreads=4' VariantFiltration \
+        -R \$PWD/${ref} \
+        -I \$PWD/${vcf} \
+        -O \$PWD/${vcf.simpleName}_filtered.vcf \
+        ${filtering_args}
+    """
+}
+
+workflow VARIANT_PROCESSING {
+    take:
+        vcfs // Sample ID + vcfs
+        ref_auxillary
+    main:
+        haplotype_vcf = VariantFiltering(bam_split_n,
+                                ref_auxillary.out.fai,
+                                ref_auxillary.out.dict,
+                                ref_auxillary.out.ref)
+    emit:
+        haplotype_vcf
+}

--- a/variant_processing.nf
+++ b/variant_processing.nf
@@ -1,4 +1,49 @@
-process VariantFiltering {
+
+
+process LearnReadOrientationModel {
+    // This requires all the f1r2 files from scattered analysis
+    input:
+    val(all_f1r2)
+
+    output:
+    path("*.tar.gz")
+
+    script:
+
+    def input_args = ""
+    for (f1r2 in all_f1r2) {
+        input_args += "-I ${f1r2} "
+    }
+    """
+    gatk LearnReadOrientationModel -I ${input_args} -O read-orientation-model.tar.gz
+    """
+}
+
+process MergeMutectStats {
+    input:
+    val(all_stats)
+
+    output:
+    path("*.stats")
+
+    script:
+
+    def input_args = ""
+    for (stats in all_stats) {
+        input_args += "-stats ${stats} "
+    }
+    """
+    gatk MergeMutectStats \
+        ${input_args}
+        -O merged.stats
+    """
+}
+
+
+
+
+
+process VariantFiltration {
     label 'variant_calling'
     publishDir "${params.output_dir}/vcf/filtered/rna_spades", mode: 'copy', overwrite: true, pattern: "*spades_*.vcf"
     publishDir "${params.output_dir}/vcf/filtered/Trinity-GG", mode: 'copy', overwrite: true, pattern: "*Trinity-GG_*.vcf"


### PR DESCRIPTION
This pull request adds parallelisation for the GATK processes, which tend to be single-core for a lot of their run-time when run on a single sample. To allow for a significant speedup, it is possible (as highlighted in their documentation) to split the analysis in various intervals, and in our cases these intervals are defined to be per (groups of) chromosome(s). 

This means that some GATK processes can take the `-L` i.e interval parameter, and by giving multiple of these i.e `-L 1 -L 2 -L 3`, where the names of "1","2" and "3" are the names of the chromosomes, the GATK processes are able to work on the files much faster. This type of `scatter-gather` approach makes it very useful to utilise it in HPC-based environments as each of the intervals can be submitted as separate jobs on separate nodes.

As a "consequence", there is then the process of gathering these files back, and merging them together to get the same/similar results as one would have analysing the files without the intervals. Additionally, `Mutect2` outputs different sub-files such as `.stats` and `f1r2.tar.gz`, which are useful/needed for other GATK tools for filtering the unfiltered output from `Mutect2`. This pull request sets up a base for these filtering steps and would still require further implementation, though that is out of the scope of the current pull request.


NOTE:
`HaplotypeCaller` has been replaces with `Mutect2` as data in our case will likely be somatic rather than germline, and according to documentation, `Mutect2` works a lot better with somatic-based variant calling.