### PR TITLE
(feature): circRNA analysis and miRNA target prediction; (modify): STAR simplification

### DIFF
--- a/circrna.nf
+++ b/circrna.nf
@@ -1,0 +1,163 @@
+// This would contain all the needed things for circRNA related workflow
+
+include { STAR as STAR_PAIRED } from "./mapping.nf"
+include { STAR as STAR_MATE1 } from "./mapping.nf"
+include { STAR as STAR_MATE2 } from "./mapping.nf"
+include { MIRNA_PREDICTION } from "./mirna.nf"
+
+circ = true;
+
+workflow CIRCRNA {
+         take:
+            reads      // Sample IDs + Paired end reads
+            ref_file
+            annotation
+         // Preperation (Paired, and mate-independent mapping)
+
+         main:
+                ref_idx = Channel.fromPath("${params.star_index}/*").collect()
+
+         read1 = reads.map { name, reads -> tuple(name, [reads[0]]) }
+         read2 = reads.map { name, reads -> tuple(name, [reads[1]]) }
+
+         STAR_PAIRED(reads, ref_idx, circ)
+         STAR_MATE1(read1, ref_idx, circ)
+         STAR_MATE2(read2, ref_idx, circ)
+
+         prep_dcc = STAR_PAIRED.out.junction.map { name, junction -> tuple(name, junction) }
+                                      .join(STAR_MATE1.out.junction, remainder: true)
+                                      .join(STAR_MATE2.out.junction, remainder: true)
+         prep_dcc.view()
+         
+
+         DCC(prep_dcc, ref_file, annotation)
+         DCC.out.view()
+         DCC_FILTER(DCC.out.txt, 2) // 2 = min number of bsj_reads to filter by
+
+         // Annotation
+         ch_biotypes = Channel.fromPath("${projectDir}/bin/unwanted_biotypes.txt")
+         ANNOTATION(DCC_FILTER.out.results, annotation, ch_biotypes.collect(), 200) // 200 = exon boundary
+
+         // Sequence Extraction
+         FASTA(ANNOTATION.out.bed, ref_file)
+
+
+         // miRNA Prediction
+         MIRNA_PREDICTION(FASTA.out.analysis_fasta, ANNOTATION.out.bed)
+         
+         // Identification (DCC)
+         // Quantification (CIRIquant?)
+         // Characterisation (sequence extraction e.g FUCHS)
+}
+
+
+process DCC {
+    tag "${sample}"
+
+    input:
+    tuple val(sample), path(paired), path(mate1, stageAs: "mate1.Chimeric.out.junction"), path(mate2, stageAs: "mate2.Chimeric.out.junction")
+    path ref_fasta
+    path annotation
+    // path repeats
+
+    output:
+    tuple val(sample), path("${sample}.txt"), emit: txt
+
+    script:
+    // NOTE: The "-R ${repeats}" doesn't seem to work well, causing some errors with HTSeq which DCC uses for GTF file parsing
+    """
+
+    mkdir ${sample} && mv ${sample}_Chimeric.out.junction ${sample} && printf "${sample}/${sample}_Chimeric.out.junction" > samplesheet
+    mkdir ${sample}_mate1 && mv mate1.Chimeric.out.junction ${sample}_mate1 && printf "${sample}_mate1/mate1.Chimeric.out.junction" > mate1file
+    mkdir ${sample}_mate2 && mv mate2.Chimeric.out.junction ${sample}_mate2 && printf "${sample}_mate2/mate2.Chimeric.out.junction" > mate2file
+
+    DCC @samplesheet -mt1 @mate1file -mt2 @mate2file -D -an ${annotation} -Pi -ss -F -M -Nr 1 1 -fg -A ${ref_fasta} -T ${task.cpus}
+
+    awk '{print \$6}' CircCoordinates >> strand
+    paste CircRNACount strand | tail -n +2 | awk -v OFS="\t" '{print \$1,\$2,\$3,\$5,\$4}' >> ${sample}.txt
+
+    """
+
+}
+
+
+process DCC_FILTER {
+    tag "${sample}"
+    label 'process_single'
+
+    input:
+    tuple val(sample), path(txt)
+    val bsj_reads
+
+    output:
+    tuple val(sample), path("${sample}_dcc_circs.bed"), emit: results
+    tuple val(sample), path("${sample}_dcc.bed")      , emit: matrix
+
+    script:
+    """
+    awk '{if(\$5 >= ${bsj_reads}) print \$0}' ${sample}.txt > ${sample}_dcc.filtered
+    awk -v OFS="\t" '{\$2-=1;print}' ${sample}_dcc.filtered > ${sample}_dcc.bed
+    awk -v OFS="\t" '{print \$1, \$2, \$3, \$1":"\$2"-"\$3":"\$4, \$5, \$4}' ${sample}_dcc.bed > ${sample}_dcc_circs.bed
+    """
+}
+
+process ANNOTATION {
+    tag "${sample}"
+    container "" // Doesn't need one since it uses gtfTogenePred
+
+    input:
+    tuple val(sample), path(bed)
+    path gtf
+    path biotypes
+    val exon_boundary
+
+
+    output:
+    tuple val(sample), path("${sample}.bed"), emit: bed
+    path("*.log")                         , emit: log
+    
+    script:
+    """
+    grep -vf $biotypes $gtf > filt.gtf
+    mv $bed circs.bed
+
+    annotate_outputs.sh $exon_boundary &> ${sample}.log
+    mv master_bed12.bed ${sample}.bed.tmp
+
+    awk -v FS="\t" '{print \$11}' ${sample}.bed.tmp > mature_len.tmp
+    awk -v FS="," '{for(i=t=0;i<NF;) t+=\$++i; \$0=t}1' mature_len.tmp > mature_length
+
+    paste ${sample}.bed.tmp mature_length > ${sample}.bed
+    """
+}
+
+process FASTA {
+    tag "${sample}"
+
+    // own container was missing "sed" command
+    container 'https://depot.galaxyproject.org/singularity/bedtools:2.30.0--h7d7f7ad_2'
+
+
+    input:
+    tuple val(sample), path(bed)
+    path fasta
+
+    output:
+    tuple val(sample), path("${sample}.fa"), emit: analysis_fasta
+    path("${sample}.fasta")              , emit: publish_fasta
+
+    script:
+    """
+    ## FASTA sequences (bedtools does not like the extra annotation info - split will not work properly)
+    cut -d\$'\t' -f1-12 ${sample}.bed > bed12.tmp
+    bedtools getfasta -fi $fasta -bed bed12.tmp -s -split -name > circ_seq.tmp
+
+    ## clean fasta header
+    grep -A 1 '>' circ_seq.tmp | cut -d: -f1,2,3 > ${sample}.fa && rm circ_seq.tmp
+
+    ## add backsplice sequence for miRanda Targetscan, publish canonical FASTA to results.
+    rm $fasta
+    bash ${workflow.projectDir}/bin/backsplice_gen.sh ${sample}.fa
+    """
+}
+

--- a/main.nf
+++ b/main.nf
@@ -3,6 +3,7 @@ nextflow.enable.dsl=2
 
 include { PREPROCESS } from './preprocess'
 include { MAPPING } from './mapping'
+include { CIRCRNA } from './circrna'
 include { ASSEMBLY } from './assembly'
 include { VARIANT_CALLING } from './variant_calling'
 

--- a/mirna.nf
+++ b/mirna.nf
@@ -1,0 +1,142 @@
+// After circRNA do some analyses on miRNA prediction on those sites
+
+workflow MIRNA_PREDICTION{
+
+    take:
+    circrna_fasta
+    circrna_bed12
+    
+    main:
+    //
+    // TARGETSCAN WORKFLOW:
+    //
+    
+    def mature = Channel.fromPath("${params.mirna_mature}").first()
+    println "THIS IS THE MATURE MIRNA: $params.mirna_mature"
+    TARGETSCAN_DATABASE(mature)
+    TARGETSCAN(circrna_fasta, TARGETSCAN_DATABASE.out.mature_txt)
+
+    //
+    // MIRANDA WORKFLOW:
+    // Split fasta, run miRanda and merge results back together
+    split = circrna_fasta.splitFasta(by: 10, file: true, elem: 1)
+    MIRANDA(split, mature)
+    MIRANDA_MERGE(MIRANDA.out.groupTuple())
+
+
+    //
+    // CONSOLIDATE PREDICTIONS WORKFLOW:
+    //
+
+    // consolidate_targets = TARGETSCAN.out.txt.join(MIRANDA.out.txt).join(circrna_bed12)
+    // MIRNA_TARGETS( consolidate_targets )
+}
+
+process TARGETSCAN_DATABASE {
+    tag "$mature"
+
+    container 'https://depot.galaxyproject.org/singularity/ubuntu:20.04'
+
+    input:
+    path(mature)
+
+    output:
+    path("mature.txt")  , emit: mature_txt
+    
+    script:
+    """
+    targetscan_format.sh $mature
+    """
+}
+
+process TARGETSCAN {
+    tag "${sample}"
+    queue "long" // It takes a very long time
+    container 'https://depot.galaxyproject.org/singularity/targetscan:7.0--pl5321hdfd78af_0'
+
+    input:
+    tuple val(sample), path(fasta)
+    path(mature_txt)
+
+    output:
+    tuple val(sample), path("${sample}.txt"), emit: txt
+
+    script:
+    """
+    ##format for targetscan
+    cat $fasta | grep ">" | sed 's/>//g' > id
+    cat $fasta | grep -v ">" > seq
+    paste id seq | awk -v OFS="\t" '{print \$1, "0000", \$2}' > ${sample}_ts.txt
+    # run targetscan
+    targetscan_70.pl mature.txt ${sample}_ts.txt ${sample}.txt
+    """
+}
+
+process MIRANDA {
+    tag "${sample}"
+    
+    container 'https://depot.galaxyproject.org/singularity/miranda:3.3a--h779adbc_3'
+
+    input:
+    tuple val(sample), path(query)
+    path(mirbase)
+
+    output:
+    tuple val(sample), path("*.txt"), emit: txt
+
+    script:
+    """
+    miranda \\
+        $mirbase \\
+        $query \\
+        $args \\
+        -out tmp_${sample}.out
+
+    echo "miRNA\tTarget\tScore\tEnergy_KcalMol\tQuery_Start\tQuery_End\tSubject_Start\tSubject_End\tAln_len\tSubject_Identity\tQuery_Identity" > ${sample}.txt
+    grep -A 1 "Scores for this hit:" ${sample}.out | sort | grep ">"  | cut -c 2- | tr ' ' '\t' >> ${sample}.txt
+    """
+}
+
+process MIRANDA_MERGE {
+    input:
+    tuple val(sample), path(files)
+
+    output:
+    tuple val(sample), path("${sample}.txt")
+
+    script:
+    """
+    echo tmp_* > ${sample}.txt
+    """
+}
+
+process MIRNA_TARGETS {
+    tag "$sample"
+
+    // container 'https://depot.galaxyproject.org/singularity/bedtools:2.30.0--h7d7f7ad_2'
+
+    input:
+    tuple val(sample), path(targetscan), path(miranda), path(bed12)
+
+    output:
+    tuple val(sample), path("${sample}.mirna_targets.txt"), emit: results
+
+
+    script:
+    """
+    ## reformat and sort miRanda, TargetScan outputs, convert to BED for overlaps.
+    tail -n +2 $targetscan | sort -k1,1 -k4n | awk -v OFS="\t" '{print \$1, \$2, \$4, \$5, \$9}' | awk -v OFS="\t" '{print \$2, \$3, \$4, \$1, "0", \$5}' > targetscan.bed
+    tail -n +2 $miranda | sort -k2,2 -k7n | awk -v OFS="\t" '{print \$2, \$1, \$3, \$4, \$7, \$8}' | awk -v OFS="\t" '{print \$2, \$5, \$6, \$1, \$3, \$4}' | sed 's/^[^-]*-//g' > miranda.bed
+
+    ## intersect, consolidate miRanda, TargetScan information about miRs.
+    ## -wa to output miRanda hits - targetscan makes it difficult to resolve duplicate miRNAs at MRE sites.
+    bedtools intersect -a miranda.bed -b targetscan.bed -wa > ${sample}.mirnas.tmp
+    bedtools intersect -a targetscan.bed -b miranda.bed | awk '{print \$6}' > mirna_type
+
+    ## remove duplicate miRNA entries at MRE sites.
+    ## strategy: sory by circs, sort by start position, sort by site type - the goal is to take the best site type (i.e rank site type found at MRE site).
+    paste ${sample}.mirnas.tmp mirna_type | sort -k3,3 -k2n -k7r | awk -v OFS="\t" '{print \$4,\$1,\$2,\$3,\$5,\$6,\$7}' | awk -F "\t" '{if (!seen[\$1,\$2,\$3,\$4,\$5,\$6]++)print}' | sort -k1,1 -k3n > ${sample}.mirna_targets.tmp
+    echo -e "circRNA\tmiRNA\tStart\tEnd\tScore\tEnergy_KcalMol\tSite_type" | cat - ${sample}.mirna_targets.tmp > ${sample}.mirna_targets.txt
+
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,18 +17,23 @@ params {
     reference_dir  = "";                              // Where to publish files i.e VCFs, CSV's
     reference_file = '${reference_dir}/*.{fa,fasta}'; // The reference genome
     gff_file       = '${reference_dir}/*.{}';         // The annotation for the reference genome
+    repeats        = '';
+    mirna_mature   = '';
+
 
     num_threads    = 4;
     max_memory     = '50.GB';
 
-    genome_index   = '';
+    star_index   = '';
+    hisat_index   = '';
     known_sites    = '';
 
     star_two_pass  = false;                           // Useful for splice/isoform analysis, otherwise no
 
+    // Either give samplesheet or define r1/r2 pattern
     paired         = false;                           // Whether paired data is given
-    strandedness   = "forward"
-    metadata       = 'clint_metadata.csv'             // The file containig sampleID and filepaths for the reads
+    samplesheet    = null;
+    strandedness   = "reverse"
     r1_pattern     = "_R1"                            // Pattern for Read1 files (for paired-end)
     r2_pattern     = "_R2"                            // Pattern for Read2 files (for paired-end)
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -99,10 +99,23 @@ profiles {
                 memory           = 50.GB
             }
 
-            // These don't need that much regarding cpu usage
+            withName: STAR_CIRCRNA_CIRCTOOLS {
+                queue = "long"
+            }
+
+            // These dont need that much regarding cpu usage
             withName: 'SAMTOOLS_INDEX|SAMTOOLS_SORT' {
                 cpus             = 2
                 memory           = 50.GB
+            }
+
+            withName: DCC {
+                cpus = 8
+                memory = 20.GB
+            }
+
+            withName: ANNOTATE {
+                container = ""
             }
 
         }


### PR DESCRIPTION
This pull requests serves to add some preliminary implementations of the circRNA analysis and circRNA target prediction. To achieve this the main tools used are: 
- DCC (circRNA)
- miRanda (miRNA target prediction)
- TargetScan (miRNA target prediction)

These were heavily adapted/ported over from the _nf-core/circrna_ pipeline (https://github.com/nf-core/circrna/tree/dev) with very minor changes. 

This pull request also adds the ability to provide a samplesheet instead of just a directory to provide information on where the data is. 

Additionally, the STAR process was modified to be a bit simpler in how it handles the inputs and outputs, adjusting the extra parameters for circRNA analysis on the fly.